### PR TITLE
Remove dependency on crates joinery and owo-colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -48,7 +48,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -85,29 +85,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -121,22 +104,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_ci"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "joinery"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d8bde02bbf44a562cf068a8ff4a68842df387e302a03a4de4a57fcf82ec377"
 
 [[package]]
 name = "libc"
@@ -162,16 +133,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owo-colors"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
-dependencies = [
- "supports-color 2.1.0",
- "supports-color 3.0.2",
-]
-
-[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,9 +140,9 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "ra-ap-rustc_lexer"
-version = "0.86.0"
+version = "0.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8fe6bebc2a874cc369129098fcbad855b935e2f2afad9a61645f53c1de78dd"
+checksum = "e40e2c73a197fea5bc3d83b59455d38acb5fbc6329a12a09a9e2689d55034945"
 dependencies = [
  "unicode-properties",
  "unicode-xid",
@@ -191,10 +152,10 @@ dependencies = [
 name = "rruxwry"
 version = "0.1.0"
 dependencies = [
+ "anstream",
+ "anstyle",
  "clap",
- "joinery",
  "open",
- "owo-colors",
  "ra-ap-rustc_lexer",
  "shlex",
  "smallvec",
@@ -219,25 +180,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "supports-color"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
-dependencies = [
- "is-terminal",
- "is_ci",
-]
-
-[[package]]
-name = "supports-color"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
-dependencies = [
- "is_ci",
-]
-
-[[package]]
 name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,15 +196,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,20 @@ description = "A wrapper around rust{,do}c for rust{,do}c devs"
 license = "MIT"
 publish = false
 
+
 [dependencies]
+anstyle = "1.0.10"
+# FIXME: Decide whether to use `supports-color`, `anstyle-query`,
+#        another crate or a custom impl for terminal color detection.
+# NOTE:  Get rid of this. Right now we're commited to it as `clap` also uses it.
+# NOTE:  We're only using it for enum `ColorChoice` & `ColorChoice::auto`.
+anstream = "0.6.18"
+# FIXME: Get rid of this dependency smh.
 clap = { version = "4.5.23" }
-joinery = "3.1.0"
+# Patch/vendor this to no longer transitively depend on `once_cell`.
 open = "5.3.1"
-owo-colors = { version = "4.1.0", features = ["supports-colors"] }
-ra-ap-rustc_lexer = "0.86.0"
+ra-ap-rustc_lexer = "0.88.0"
+# FIXME: Write own implementation that tracks source location / span.
 shlex = "1.3.0"
 smallvec = { version = "1.13.1", features = ["const_generics"] }
 

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -1,6 +1,6 @@
 use crate::{
     data::{CrateName, CrateNameRef, CrateType, Edition},
-    diagnostic::info,
+    diagnostic::note,
     utility::{
         SmallVec,
         parse::{At, SourceFileParser, Span},
@@ -43,7 +43,7 @@ impl<'src> Attributes<'src> {
 
         if verbose {
             let s = if amount == 1 { "" } else { "s" };
-            info(format!("parser: found {amount} crate attribute{s}")).emit();
+            note!("parser: found {amount} crate attribute{s}");
         }
 
         let attributes = Self::lower(attributes, cfgs, source);
@@ -51,17 +51,15 @@ impl<'src> Attributes<'src> {
         if amount != 0 && verbose {
             let verb = |present| if present { "found" } else { "did not find" };
 
-            info(format!(
+            note!(
                 "lowerer: {} a well-formed `#![crate_name]`",
                 verb(attributes.crate_name.is_some()),
-            ))
-            .emit();
+            );
 
-            info(format!(
+            note!(
                 "lowerer: {} a well-formed `#![crate_type]`",
                 verb(attributes.crate_type.is_some()),
-            ))
-            .emit();
+            );
         }
 
         attributes

--- a/src/command.rs
+++ b/src/command.rs
@@ -11,16 +11,17 @@
 
 use crate::{
     data::{CrateName, CrateNameRef, CrateType, DocBackend, Edition},
-    diagnostic::info,
+    diagnostic::{self, note},
     error::Result,
     interface,
-    utility::default,
+    utility::{default, paint::IntoStyle},
 };
-use owo_colors::OwoColorize;
+use anstyle::{AnsiColor, Effects, Style};
 use std::{
     borrow::Cow,
     ffi::OsStr,
     fmt,
+    io::{self, Write},
     ops::{Deref, DerefMut},
     path::Path,
     process,
@@ -152,14 +153,14 @@ pub(crate) fn open(crate_name: CrateNameRef<'_>, flags: &interface::DebugFlags) 
     let path = std::env::current_dir()?.join("doc").join(crate_name.as_str()).join("index.html");
 
     if flags.verbose {
-        let verb = if !flags.dry_run { "running" } else { "skipping" };
-
-        info(format!(
-            "{verb} {} {}",
-            "⟨browser⟩".color(palette::COMMAND).bold(),
-            path.to_string_lossy().green()
-        ))
-        .emit();
+        note!(|p| {
+            let verb = if !flags.dry_run { "running" } else { "skipping" };
+            write!(p, "{verb} ")?;
+            p.with(palette::COMMAND.on_default().effects(Effects::BOLD), |p| {
+                write!(p, "⟨browser⟩ ")
+            })?;
+            p.with(AnsiColor::Green, |p| write!(p, "{}", path.display()))
+        });
     }
 
     if !flags.dry_run {
@@ -206,12 +207,11 @@ impl<'a> Command<'a> {
             return;
         }
 
-        let verb = if !self.flags.dry_run { "running" } else { "skipping" };
-        let mut message = String::from(verb);
-        message += " ";
-        self.render_into(&mut message).unwrap();
-
-        info(message).emit();
+        note!(|p| {
+            let verb = if !self.flags.dry_run { "running" } else { "skipping" };
+            write!(p, "{verb} ")?;
+            self.render_into(p)
+        });
     }
 
     fn set_toolchain(&mut self, flags: Flags<'_>) {
@@ -346,32 +346,35 @@ impl DerefMut for Command<'_> {
 }
 
 trait CommandExt {
-    fn render_into(&self, buffer: &mut String) -> fmt::Result;
+    fn render_into(&self, p: &mut diagnostic::Painter) -> io::Result<()>;
 }
 
 // This is very close to `<process::Command as fmt::Debug>::fmt` but prettier.
+// FIXME: This lacks shell escaping!
 impl CommandExt for process::Command {
-    fn render_into(&self, buffer: &mut String) -> fmt::Result {
-        use std::fmt::Write;
+    fn render_into(&self, p: &mut diagnostic::Painter) -> io::Result<()> {
+        #[allow(irrefutable_let_patterns)]
+        if let envs = self.get_envs()
+            && !envs.is_empty()
+        {
+            p.set(palette::VARIABLE)?;
+            for (key, value) in self.get_envs() {
+                // FIXME: Print `env -u VAR` for removed vars before
+                // added vars just like `Command`'s `Debug` impl.
+                let Some(value) = value else { continue };
 
-        for (key, value) in self.get_envs() {
-            // FIXME: Print `env -u VAR` for removed vars before
-            // added vars just like `Command`'s `Debug` impl.
-            let Some(value) = value else { continue };
-
-            write!(
-                buffer,
-                "{}{}{} ",
-                key.to_string_lossy().color(palette::VARIABLE).bold(),
-                "=".color(palette::VARIABLE),
-                value.to_string_lossy().color(palette::VARIABLE)
-            )?;
+                p.with(Effects::BOLD, |p| write!(p, "{}", key.display()))?;
+                write!(p, "={} ", value.display())?;
+            }
+            p.unset()?;
         }
 
-        write!(buffer, "{}", self.get_program().to_string_lossy().color(palette::COMMAND).bold())?;
+        p.with(palette::COMMAND.on_default().effects(Effects::BOLD), |p| {
+            write!(p, "{}", self.get_program().display())
+        })?;
 
         for argument in self.get_args() {
-            write!(buffer, " {}", argument.to_string_lossy().color(palette::ARGUMENT))?;
+            p.with(palette::ARGUMENT, |p| write!(p, " {}", argument.display()))?;
         }
 
         Ok(())
@@ -379,11 +382,11 @@ impl CommandExt for process::Command {
 }
 
 mod palette {
-    use owo_colors::AnsiColors;
+    use anstyle::AnsiColor;
 
-    pub(super) const VARIABLE: AnsiColors = AnsiColors::Yellow;
-    pub(super) const COMMAND: AnsiColors = AnsiColors::Magenta;
-    pub(super) const ARGUMENT: AnsiColors = AnsiColors::Green;
+    pub(super) const VARIABLE: AnsiColor = AnsiColor::Yellow;
+    pub(super) const COMMAND: AnsiColor = AnsiColor::Magenta;
+    pub(super) const ARGUMENT: AnsiColor = AnsiColor::Green;
 }
 
 #[derive(Clone)]

--- a/src/command/environment.rs
+++ b/src/command/environment.rs
@@ -37,14 +37,14 @@ fn parse_flags(
 ) -> Option<Vec<String>> {
     for &confusable in confusables {
         if environment.contains_key(confusable) {
-            warning::environment_contains_confusable_variable(confusable, key).emit();
+            warning::emit_env_contains_confusable_var(confusable, key);
         }
     }
 
     let flags = environment.get(key)?;
 
     let Some(flags) = flags.to_str() else {
-        warning::malformed_environment_variable(key, "its content is not valid UTF-8").emit();
+        warning::emit_malformed_env_var(key, "its content is not valid UTF-8");
 
         return None;
     };
@@ -52,30 +52,26 @@ fn parse_flags(
     let flags = shlex::split(flags);
 
     if flags.is_none() {
-        warning::malformed_environment_variable(key, "its content is not properly escaped").emit();
+        warning::emit_malformed_env_var(key, "its content is not properly escaped");
     }
 
     flags
 }
 
 mod warning {
-    use crate::diagnostic::{Diagnostic, warning};
+    use crate::diagnostic::warning;
     use std::ffi::OsStr;
 
-    pub(super) fn environment_contains_confusable_variable(
-        confusable: &OsStr,
-        suggestion: &OsStr,
-    ) -> Diagnostic {
-        warning(format!(
-            "rruxwry does not read the environment variable `{}`",
-            confusable.display()
-        ))
-        .note(format!("you might have meant `{}`", suggestion.display()))
+    pub(super) fn emit_env_contains_confusable_var(confusable: &OsStr, suggestion: &OsStr) {
+        warning!("rruxwry does not read the environment variable `{}`", confusable.display())
+        // FIXME: add back note
+        // .note(format!("you might have meant `{}`", suggestion.display()))
     }
 
-    pub(super) fn malformed_environment_variable(key: &OsStr, note: &'static str) -> Diagnostic {
-        warning(format!("the environment variable `{}` is malformed", key.display()))
-            .note(note)
-            .note("ignoring all flags potentially contained within it")
+    pub(super) fn emit_malformed_env_var(key: &OsStr, note: &'static str) {
+        warning!("the environment variable `{}` is malformed", key.display())
+        // FIXME: add back notes
+        // .note(note)
+        // .note("ignoring all flags potentially contained within it")
     }
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -3,10 +3,9 @@
 use crate::{
     data::{CrateNameBuf, CrateType, DocBackend, Edition},
     operate::{BuildMode, DocMode},
-    utility::parse,
+    utility::{Conjunction, ListingExt as _, parse},
 };
 use clap::ColorChoice;
-use joinery::JoinableIterator;
 use std::{ffi::OsString, path::PathBuf};
 
 // FIXME: Improve naming: *Flags, Arguments, ...
@@ -398,7 +397,7 @@ impl CrateType {
 fn possible_values(values: impl Iterator<Item: std::fmt::Display> + Clone) -> String {
     format!(
         "possible values: {}",
-        values.into_iter().map(|value| format!("`{value}`")).join_with(", ")
+        values.into_iter().map(|value| format!("`{value}`")).list(Conjunction::Or)
     )
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 #![feature(decl_macro)]
+#![feature(exact_size_is_empty)]
 #![feature(exit_status_error)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(let_chains)]
@@ -13,7 +14,6 @@
 
 use attribute::Attributes;
 use data::{CrateNameBuf, CrateNameCow, CrateType, Edition};
-use diagnostic::IntoDiagnostic;
 use std::{path::Path, process::ExitCode};
 
 mod attribute;
@@ -36,7 +36,7 @@ fn main() -> ExitCode {
     match result {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
-            error.into_diagnostic().emit();
+            error.emit();
             ExitCode::FAILURE
         }
     }
@@ -46,8 +46,8 @@ fn try_main() -> error::Result {
     let args = interface::arguments();
 
     match args.color {
-        clap::ColorChoice::Always => owo_colors::set_override(true),
-        clap::ColorChoice::Never => owo_colors::set_override(false),
+        clap::ColorChoice::Always => anstream::ColorChoice::Always.write_global(),
+        clap::ColorChoice::Never => anstream::ColorChoice::Never.write_global(),
         clap::ColorChoice::Auto => {}
     }
 

--- a/src/operate.rs
+++ b/src/operate.rs
@@ -5,12 +5,11 @@
 use crate::{
     command::{self, ExternCrate, Flags, Strictness},
     data::{CrateName, CrateNameCow, CrateNameRef, CrateType, DocBackend, Edition},
-    diagnostic::{Diagnostic, IntoDiagnostic, error},
+    diagnostic::error,
     directive,
     error::Result,
-    utility::default,
+    utility::{Conjunction, ListingExt as _, default},
 };
-use joinery::JoinableIterator;
 use std::{borrow::Cow, cell::LazyCell, collections::BTreeSet, mem, path::Path};
 
 pub(crate) fn build(
@@ -400,16 +399,17 @@ pub(crate) enum Error {
     UnknownRevision { unknown: String, available: BTreeSet<String> },
 }
 
-impl IntoDiagnostic for Error {
-    fn into_diagnostic(self) -> Diagnostic {
+impl Error {
+    pub(crate) fn emit(self) {
         match self {
-            Error::UnknownRevision { unknown, available } => {
+            Self::UnknownRevision { unknown, available } => {
                 let available =
-                    available.iter().map(|revision| format!("`{revision}`")).join_with(", ");
+                    available.iter().map(|revision| format!("`{revision}`")).list(Conjunction::And);
 
-                error(format!("unknown revision `{unknown}`"))
-                    .note(format!("available revisions are: {available}"))
-                    .note("you can use `--cfg` over `--rev` to suppress this check")
+                error!("unknown revision `{unknown}`")
+                // FIXME: add back notes
+                // .note(format!("available revisions are: {available}"))
+                // .note("you can use `--cfg` over `--rev` to suppress this check")
             }
         }
     }

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+pub(crate) mod paint;
 pub(crate) mod parse;
 
 pub(crate) type Str = Cow<'static, str>;
@@ -15,4 +16,48 @@ pub(crate) macro parse($( $( $key:literal )|+ => $value:expr ),+ $(,)?) {
         $( $( $key )|+ => $value, )+
         _ => return Err([$( $( $key ),+ ),+].into_iter()),
     })
+}
+
+pub(crate) trait ListingExt {
+    fn list(self, conjunction: Conjunction) -> String;
+}
+
+impl<I: Iterator<Item: Clone + std::fmt::Display>> ListingExt for I {
+    fn list(self, conjunction: Conjunction) -> String {
+        let mut items = self.peekable();
+        let mut first = true;
+        let mut result = String::new();
+
+        while let Some(item) = items.next() {
+            if !first {
+                if items.peek().is_some() {
+                    result += ", ";
+                } else {
+                    result += " ";
+                    result += conjunction.to_str();
+                    result += " ";
+                }
+            }
+
+            result += &item.to_string();
+            first = false;
+        }
+
+        result
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum Conjunction {
+    And,
+    Or,
+}
+
+impl Conjunction {
+    const fn to_str(self) -> &'static str {
+        match self {
+            Self::And => "and",
+            Self::Or => "or",
+        }
+    }
 }

--- a/src/utility/paint.rs
+++ b/src/utility/paint.rs
@@ -1,0 +1,118 @@
+use super::{SmallVec, default};
+use anstyle::{AnsiColor, Effects, Style};
+use std::io::{self, BufWriter, StderrLock, StdoutLock, Write};
+
+// FIXME: remove these again maybe
+pub(crate) type BufStdoutPainter = Painter<BufWriter<StdoutLock<'static>>>;
+pub(crate) type BufStderrPainter = Painter<BufWriter<StderrLock<'static>>>;
+
+// pub(crate) fn paint(
+//     paint: impl FnOnce(&mut BufStdoutPainter) -> io::Result<()>,
+//     choice: ColorChoice,
+// ) -> io::Result<()> {
+//     let mut painter = Painter::stdout(choice);
+//     paint(&mut painter)?;
+//     painter.flush()
+// }
+
+// pub(crate) fn epaint(
+//     paint: impl FnOnce(&mut BufStderrPainter) -> io::Result<()>,
+//     choice: ColorChoice,
+// ) -> io::Result<()> {
+//     let mut painter = Painter::stderr(choice);
+//     paint(&mut painter)?;
+//     painter.flush()
+// }
+
+pub(crate) struct Painter<W: Write> {
+    writer: W,
+    colorize: bool,
+    stack: SmallVec<Style, 1>,
+}
+
+impl<W: Write> Painter<W> {
+    pub(crate) fn new(writer: W, colorize: bool) -> Self {
+        Self { writer, colorize, stack: default() }
+    }
+}
+
+impl<W: Write> Painter<W> {
+    pub(crate) fn set(&mut self, style: impl IntoStyle) -> io::Result<()> {
+        if !self.colorize {
+            return Ok(());
+        }
+
+        let style = style.into_style();
+        self.stack.push(style);
+        style.write_to(&mut self.writer)
+    }
+
+    pub(crate) fn unset(&mut self) -> io::Result<()> {
+        if !self.colorize {
+            return Ok(());
+        }
+
+        if let Some(style) = self.stack.pop() {
+            style.write_reset_to(&mut self.writer)?;
+        }
+
+        for style in &self.stack {
+            style.write_to(&mut self.writer)?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn with(
+        &mut self,
+        style: impl IntoStyle,
+        inner: impl FnOnce(&mut Self) -> io::Result<()>,
+    ) -> io::Result<()> {
+        self.set(style)?;
+        inner(self)?;
+        self.unset()
+    }
+}
+
+impl<W: Write> Write for Painter<W> {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.writer.write(buffer)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush()
+    }
+}
+
+pub(crate) trait IntoStyle {
+    fn into_style(self) -> Style;
+}
+
+impl IntoStyle for Style {
+    fn into_style(self) -> Style {
+        self
+    }
+}
+
+impl IntoStyle for AnsiColor {
+    fn into_style(self) -> Style {
+        self.on_default()
+    }
+}
+
+impl IntoStyle for Effects {
+    fn into_style(self) -> Style {
+        Style::new().effects(self)
+    }
+}
+
+#[allow(dead_code)] // may come in clutch at some point
+pub(crate) trait ColorExt {
+    fn to_bg(self) -> Style;
+}
+
+impl ColorExt for AnsiColor {
+    fn to_bg(self) -> Style {
+        Style::new().bg_color(Some(self.into()))
+    }
+}


### PR DESCRIPTION
`cargo tree` before:

```
rruxwry v0.1.0 (/home/fmease/programming/projects/rruxwry)
├── clap v4.5.23
│   └── clap_builder v4.5.23
│       ├── anstream v0.6.18
│       │   ├── anstyle v1.0.10
│       │   ├── anstyle-parse v0.2.6
│       │   │   └── utf8parse v0.2.2
│       │   ├── anstyle-query v1.1.2
│       │   ├── colorchoice v1.0.3
│       │   ├── is_terminal_polyfill v1.70.1
│       │   └── utf8parse v0.2.2
│       ├── anstyle v1.0.10
│       ├── clap_lex v0.7.4
│       └── strsim v0.11.1
├── joinery v3.1.0
├── open v5.3.1
│   ├── is-wsl v0.4.0
│   │   ├── is-docker v0.2.0
│   │   │   └── once_cell v1.20.2
│   │   └── once_cell v1.20.2
│   ├── libc v0.2.168
│   └── pathdiff v0.2.3
├── owo-colors v4.1.0
│   ├── supports-color v2.1.0
│   │   ├── is-terminal v0.4.13
│   │   │   └── libc v0.2.168
│   │   └── is_ci v1.2.0
│   └── supports-color v3.0.2
│       └── is_ci v1.2.0
├── ra-ap-rustc_lexer v0.86.0
│   ├── unicode-properties v0.1.3
│   └── unicode-xid v0.2.6
├── shlex v1.3.0
└── smallvec v1.13.2
```

`cargo tree` after:

```
rruxwry v0.1.0 (/home/fmease/programming/projects/rruxwry)
├── anstream v0.6.18
│   ├── anstyle v1.0.10
│   ├── anstyle-parse v0.2.6
│   │   └── utf8parse v0.2.2
│   ├── anstyle-query v1.1.2
│   ├── colorchoice v1.0.3
│   ├── is_terminal_polyfill v1.70.1
│   └── utf8parse v0.2.2
├── anstyle v1.0.10
├── clap v4.5.23
│   └── clap_builder v4.5.23
│       ├── anstream v0.6.18 (*)
│       ├── anstyle v1.0.10
│       ├── clap_lex v0.7.4
│       └── strsim v0.11.1
├── open v5.3.1
│   ├── is-wsl v0.4.0
│   │   ├── is-docker v0.2.0
│   │   │   └── once_cell v1.20.2
│   │   └── once_cell v1.20.2
│   ├── libc v0.2.168
│   └── pathdiff v0.2.3
├── ra-ap-rustc_lexer v0.88.0
│   ├── unicode-properties v0.1.3
│   └── unicode-xid v0.2.6
├── shlex v1.3.0
└── smallvec v1.13.2
```