### PR TITLE
Support `--identity` in ancient versions, too

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rustc-env=TARGET={}", std::env::var("TARGET").unwrap());
+}


### PR DESCRIPTION
See: #42 